### PR TITLE
Body Parser Options

### DIFF
--- a/examples/deps.ts
+++ b/examples/deps.ts
@@ -1,13 +1,13 @@
-export { bootstrap } from "https://deno.land/x/cargo@0.1.52/mod.ts";
+export { bootstrap } from "https://deno.land/x/cargo@0.1.53/mod.ts";
 
 export {
   Get,
   type UrlParams,
-} from "https://deno.land/x/cargo@0.1.52/http/mod.ts";
+} from "https://deno.land/x/cargo@0.1.53/http/mod.ts";
 
 export {
   Authenticator,
   LocalStrategy,
-} from "https://deno.land/x/cargo@0.1.52/auth/mod.ts";
+} from "https://deno.land/x/cargo@0.1.53/auth/mod.ts";
 
-export { logTimeToResponse } from "https://deno.land/x/cargo@0.1.52/middleware/mod.ts";
+export { logTimeToResponse } from "https://deno.land/x/cargo@0.1.53/middleware/mod.ts";

--- a/examples/hello-world.ts
+++ b/examples/hello-world.ts
@@ -21,4 +21,4 @@ Get("/:message", ({ params }) => {
 /*
  * 4. Bootstrap and Run the Application
  */
-(await bootstrap()).run();
+(await bootstrap({ defaultProtocolOptions: { legacyServe: false } })).run();

--- a/inspect/mod.ts
+++ b/inspect/mod.ts
@@ -1,3 +1,3 @@
-// Cargo Inspect – Version 0.1.52
+// Cargo Inspect – Version 0.1.55
 export * from "./schema.ts";
 export * from "./schemas/mod.ts";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,2 @@
 export const NAME = "Cargo";
-export const CARGO_PORT = 8000;
+export const CARGO_DEFAULT_PORT = 8000;

--- a/src/http/mod.ts
+++ b/src/http/mod.ts
@@ -1,4 +1,4 @@
-// Cargo/http – Version 0.1.52
+// Cargo/http – Version 0.1.53
 export * from "./exceptions/mod.ts";
 export * from "./http-method.ts";
 export * from "./http-status.ts";

--- a/src/http/request.ts
+++ b/src/http/request.ts
@@ -1,4 +1,5 @@
 import { HttpMethod, Route } from "./mod.ts";
+import { type ProtocolConnectionInfo } from "../mod.ts";
 
 export type Handler = (cxt: RequestContext) => Promise<Response> | Response;
 
@@ -8,7 +9,7 @@ export type UrlParams = Record<string, string | undefined>;
 
 export interface RequestContext {
   request: Request;
-  connection: Deno.ServeHandlerInfo;
+  connection: ProtocolConnectionInfo;
   params?: UrlParams;
   body?: unknown;
   auth?: unknown;

--- a/src/middleware/body-parser/body-parser.test.ts
+++ b/src/middleware/body-parser/body-parser.test.ts
@@ -1,4 +1,4 @@
-import { parseBody } from "./body-parser.ts";
+import { bodyParser } from "./body-parser.ts";
 import { assertEquals, assertRejects } from "std/testing/asserts.ts";
 import { EntityTooLargeException } from "../../http/mod.ts";
 
@@ -11,7 +11,7 @@ const requestOptions = {
 
 Deno.test("Body Parser:", async (t) => {
   await t.step("parse if body size not exceeds the max size", async () => {
-    await parseBody({ maxBodySize: 3 })({
+    await bodyParser({ maxBodySize: 3 })({
       request: new Request("https://cargo.wtf", {
         ...requestOptions,
         body: '"a"',
@@ -27,7 +27,7 @@ Deno.test("Body Parser:", async (t) => {
     () => {
       assertRejects(
         () => {
-          return parseBody({ maxBodySize: 2 })({
+          return bodyParser({ maxBodySize: 2 })({
             request: new Request("https://cargo.wtf", {
               ...requestOptions,
               body: '"a"',
@@ -44,7 +44,7 @@ Deno.test("Body Parser:", async (t) => {
   await t.step(
     "handle undefined body",
     () => {
-      parseBody()({
+      bodyParser()({
         request: new Request("https://cargo.wtf", {
           ...requestOptions,
         }),
@@ -61,7 +61,7 @@ Deno.test("Body Parser:", async (t) => {
     };
     const jsonAsString = JSON.stringify(json);
 
-    await parseBody()({
+    await bodyParser()({
       request: new Request("https://cargo.wtf", {
         ...requestOptions,
         body: jsonAsString,
@@ -76,7 +76,7 @@ Deno.test("Body Parser:", async (t) => {
     const json = "";
     const jsonAsString = JSON.stringify(json);
 
-    await parseBody()({
+    await bodyParser()({
       request: new Request("https://cargo.wtf", {
         ...requestOptions,
         body: jsonAsString,
@@ -93,7 +93,7 @@ Deno.test("Body Parser:", async (t) => {
       const json = "peng";
       assertRejects(
         () => {
-          return parseBody()({
+          return bodyParser()({
             request: new Request("https://cargo.wtf", {
               ...requestOptions,
               body: json,

--- a/src/middleware/body-parser/body-parser.ts
+++ b/src/middleware/body-parser/body-parser.ts
@@ -11,17 +11,17 @@ export interface Parser<T> {
   parse: (buffer: Uint8Array) => T;
 }
 
-interface ParserOptions {
+export interface BodyParserOptions {
   maxBodySize: number;
   paser?: Parser<unknown>[];
 }
 
-const defaultOptions: ParserOptions = {
+const defaultOptions: BodyParserOptions = {
   maxBodySize: 1024,
   paser: [JSONParser],
 };
 
-export function parseBody(parserOptions?: ParserOptions) {
+export function bodyParser(parserOptions?: Partial<BodyParserOptions>) {
   const options = { ...defaultOptions, ...parserOptions };
   return async (ctx: RequestContext, next: Next) => {
     const contentType = ctx.request.headers.get("content-type")?.split(" ")[0]

--- a/src/middleware/mod.ts
+++ b/src/middleware/mod.ts
@@ -1,5 +1,5 @@
-// Cargo/middleware – Version 0.1.52
-export { parseBody } from "./body-parser/body-parser.ts";
+// Cargo/middleware – Version 0.1.53
+export { bodyParser } from "./body-parser/body-parser.ts";
 export * from "./middleware.ts";
 export { addRawBodyToContext } from "./add-raw-body-to-context.ts";
 export { addSearchParamsToContext } from "./add-search-params-to-context.ts";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,4 +1,5 @@
-// Cargo – Version 0.1.52
+// Cargo – Version 0.1.53
 export * from "./app.ts";
 export * from "./constants.ts";
+export * from "./protocol.ts";
 export * from "./tasks.ts";

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,0 +1,16 @@
+import { Middleware } from "./middleware/mod.ts";
+
+export type ProtocolConnectionInfo = {
+  remoteAddr: ProtocolRemoteAddress;
+};
+
+export type ProtocolRemoteAddress = {
+  transport: string;
+  hostname?: string;
+  port?: number;
+};
+
+export type Protocol = {
+  listen(port?: number): void;
+  middleware(middleware: Middleware[] | Middleware): Protocol;
+};

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -13,29 +13,23 @@ export interface ToRegister {
 
 export type Tasks = Record<Hooks, Task[]>;
 
-const registry: Tasks = {
-  onBootstrap: [],
-};
+export class TaskWorker {
+  #registry: Tasks = { onBootstrap: [] };
 
-function add(task: ToRegister) {
-  registry[task.type].push(task.task);
-}
+  add(task: ToRegister) {
+    this.#registry[task.type].push(task.task);
+  }
 
-function hooks(hookType: Hooks): Task[] {
-  return registry[hookType];
-}
+  hooks(hookType: Hooks): Task[] {
+    return this.#registry[hookType];
+  }
 
-async function process(tasks: Task[], app: App) {
-  for (const task of tasks) {
-    if (task instanceof Promise) {
-      await task(app);
+  async process(tasks: Task[], app: App) {
+    for (const task of tasks) {
+      if (task instanceof Promise) {
+        await task(app);
+      }
+      await Promise.resolve(task(app));
     }
-    await Promise.resolve(task(app));
   }
 }
-
-export const TaskWorker = {
-  add,
-  hooks,
-  process,
-};

--- a/src/utils/mod.ts
+++ b/src/utils/mod.ts
@@ -1,4 +1,4 @@
-// Cargo/utils – Version 0.1.52
+// Cargo/utils – Version 0.1.53
 export * from "./file.ts";
 export * from "./logger.ts";
 export * from "./mime-types.ts";


### PR DESCRIPTION
- Pass down body parser options to middleware
- Refactor application layer
- add legacyServe option for environments without Deno.serve support
- Add generic ProtocolConnection info for connection info